### PR TITLE
Update OCROptions.cs

### DIFF
--- a/C#/OCR_Examples/OCR_Examples/Examples/OCROptions.cs
+++ b/C#/OCR_Examples/OCR_Examples/Examples/OCROptions.cs
@@ -18,7 +18,7 @@ namespace OCR_Examples.Examples
             ocr.Settings.OCR.Deskew = OCRData.Enums.ImageProcessing.DeskewOptions.Auto2D;
             ocr.Settings.OCR.Despeckled = true;
             ocr.Settings.OCR.ExportBookmarks = false;
-            ocr.Settings.OCR.OCRType = OCRData.Enums.OCR.OCRTypeOptions.SearchablePDF;
+            ocr.Settings.OCRType = OCRData.Enums.OCR.OCRTypeOptions.SearchablePDF;
             ocr.Settings.OCR.PictureHandling = OCRData.Enums.OCR.PictureHandlingOptions.Default;
             ocr.Settings.OCR.RetainLineNumbering = false;
             ocr.Settings.OCR.Rotation = OCRData.Enums.ImageProcessing.RotationOptions.Auto;


### PR DESCRIPTION
Property "OCRType" was moved after 4.2.0.20024 release of OCRConverter. Updating OCROptions.cs to reflect new location.